### PR TITLE
instead of relying on docs.tar.gz, download tag tarball

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apk update \
 
 RUN mkdir -p /etc/shared \
         && mkdir -p /var/www/public/errors
+
 COPY entrypoint.sh .
 COPY supervisord.conf /etc/supervisord.conf
 COPY bin /bin

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# docsrv
+# docsrv [![Build Status](https://travis-ci.org/src-d/docsrv.svg?branch=master)](https://travis-ci.org/src-d/docsrv)
 
 `docsrv` is an app to serve versioned documentation for GitHub projects on demand.
 Every time a documentation is requested for a version that is not on the server, it is fetched from a GitHub release and installed locally to be served by the Caddy webserver.
@@ -32,18 +32,20 @@ Will output something like this:
 ]
 ```
 
-
 ### Release format
 
-A GitHub release can only be used with `docsrv` if it contains a `docs.tar.gz` asset, is not a draft and is not a pre-release.
+To build the documentation site of your project version, docsrv will download the tarball of the version with the contents your project had at that time. It is required to have a `Makefile` with a task named `docs`.
 
-This `docs.tar.gz` will need to have a `Makefile` in its root with a rule named `build`.
+What docsrv will run to build your documentation is `make docs`, all the rest is handled by the makefile itself. Three parameters for the correct build of the documentation site are passed as environment variables.
 
-The following environment variables will be available for the makefile to use and build itself.
+* `DESTINATION_FOLDER`: root folder where the documentation site should be built by the makefile.
+* `SHARED_FOLDER`: a shared folder where the makefile can store things (for example, to cache templates, etc).
+* `BASE_URL`: the base url of the project site (e.g. `http://project.mydomain.tld/v1.0.0`).
 
-* `BASE_URL`: base url of that project version e.g. `http://project.domain.tld/v1.0.0`.
-* `DESTINATION_FOLDER`: folder where the docs should be built.
-* `SHARED_REPO_FOLDER`: folder where the shared repo, if any, is.
+
+### Release restrictions
+
+A GitHub release can only be used with `docsrv` if is not a draft and is not a pre-release.
 
 ### Install and run
 
@@ -53,7 +55,6 @@ docker build -t docsrv .
 docker run -p 9090:9090 --name docsrv-instance \
         -e GITHUB_API_KEY "(optional) your github api key" \
         -e GITHUB_ORG "your github org/user name" \
-        -e SHARED_REPO "(optional) url of the the repo" \
         -v /path/to/host/logs:/var/log/docsrv \
         -v /path/to/error/pages:/var/www/public/errors \
         docsrv
@@ -61,6 +62,5 @@ docker run -p 9090:9090 --name docsrv-instance \
 
 **Notes:**
 
-* `SHARED_REPO` will be downloaded at the start of the container. It can be used to download a repo that will contain files needed by the docs to be built.
 * If not `GITHUB_API_KEY` is provided, the requests will not be authenticated. That means harder rate limits and unability to fetch private repositories.
 * To override the error pages, mount a volume on `/var/www/public/errors` with `404.html` and `500.html`. If any of these two files does not exist, they will be created when the container starts. You may use assets contained in the same errors folder as if they were on the root of the site.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,21 +1,13 @@
 #!/bin/sh
 
-# clone shared repo if any
-if [ -n $SHARED_REPO ]; then
-        git clone $SHARED_REPO /etc/shared
-        if [ $? -ne 0 ]; then
-                exit 1;
-        fi
-fi
-
 # create 404 page if not exists
 if [ ! -f /var/www/public/errors/404.html ]; then
-        echo '<h1>Not Found</h1>' > /var/www/public/errors/404.html
+        echo '<h1>Not Found</h1>' > /var/www/public/errors/404.html;
 fi
 
 # create 500 page if not exists
 if [ ! -f /var/www/public/errors/500.html ]; then
-        echo '<h1>Server Error</h1>' > /var/www/public/errors/500.html
+        echo '<h1>Server Error</h1>' > /var/www/public/errors/500.html;
 fi
 
 /usr/bin/supervisord

--- a/srv/build.go
+++ b/srv/build.go
@@ -11,7 +11,7 @@ import (
 	"github.com/c4milo/unpackit"
 )
 
-func buildDocs(docsURL, baseURL, destination string) error {
+func buildDocs(docsURL, baseURL, destination, sharedFolder string) error {
 	resp, err := http.Get(docsURL)
 	if err != nil {
 		return err
@@ -28,16 +28,13 @@ func buildDocs(docsURL, baseURL, destination string) error {
 		return fmt.Errorf("error untarring %q: %s", docsURL, err)
 	}
 
-	cmd := exec.Command(
-		"make",
-		"build",
-	)
+	cmd := exec.Command("make", "docs")
 	cmd.Dir = dir
 	cmd.Env = append(
 		os.Environ(),
 		"BASE_URL="+baseURL,
 		"DESTINATION_FOLDER="+destination,
-		"SHARED_REPO_FOLDER="+sharedFolder,
+		"SHARED_FOLDER="+sharedFolder,
 	)
 
 	output, err := cmd.CombinedOutput()

--- a/srv/build_test.go
+++ b/srv/build_test.go
@@ -15,6 +15,6 @@ func TestBuildDocs(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("", "docsrv-test-")
 	require.NoError(err)
 
-	require.NoError(buildDocs(url, "http://foo.bar", tmpDir))
+	require.NoError(buildDocs(url, "http://foo.bar", tmpDir, defaultSharedFolder))
 	assertMakefileOutput(t, tmpDir, "http://foo.bar")
 }

--- a/srv/docsrv_test.go
+++ b/srv/docsrv_test.go
@@ -93,6 +93,7 @@ func TestPrepareVersion(t *testing.T) {
 	github := newGitHubMock()
 	srv := newTestSrv(github)
 	srv.baseFolder = tmpDir
+	srv.sharedFolder = defaultSharedFolder
 
 	github.add("foo", "v1.0.0", url)
 

--- a/srv/github_test.go
+++ b/srv/github_test.go
@@ -6,14 +6,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestReleases(t *testing.T) {
+func TestGitHubReleases(t *testing.T) {
 	require := require.New(t)
 	github := NewGitHub("", "erizocosmico")
 
-	releases, err := github.Releases("test-docsrv", true)
+	releases, err := github.Releases("test-docsrv")
 	require.NoError(err)
 
-	expected := []string{"v1.2.0", "v1.4.0"}
+	expected := []string{"v1.0.0", "v1.4.0", "v1.5.0"}
 	var result []string
 	for _, r := range releases {
 		result = append(result, r.Tag)
@@ -22,7 +22,7 @@ func TestReleases(t *testing.T) {
 	require.Equal(expected, result)
 }
 
-func TestRelease(t *testing.T) {
+func TestGitHubRelease(t *testing.T) {
 	require := require.New(t)
 	github := NewGitHub("", "erizocosmico")
 
@@ -32,4 +32,13 @@ func TestRelease(t *testing.T) {
 	release, err = github.Release("test-docsrv", "v1.4.0")
 	require.NoError(err)
 	require.Equal("v1.4.0", release.Tag)
+}
+
+func TestGitHubLatest(t *testing.T) {
+	require := require.New(t)
+	github := NewGitHub("", "erizocosmico")
+
+	release, err := github.Latest("test-docsrv")
+	require.NoError(err)
+	require.Equal("v1.5.0", release.Tag)
 }


### PR DESCRIPTION
Instead of checking the releases with `docs.tar.gz` assets, now it downloads directly the tarball with all the source code and uses `make docs` on it.