### PR TITLE
send DOCSRV environment variable to `make docs`

### DIFF
--- a/srv/build.go
+++ b/srv/build.go
@@ -48,6 +48,7 @@ func buildDocs(conf buildConfig) error {
 		"REPOSITORY="+conf.project,
 		"REPOSITORY_OWNER="+conf.owner,
 		"VERSION_NAME="+conf.version,
+		"DOCSRV=true",
 	)
 
 	output, err := cmd.CombinedOutput()

--- a/srv/util_test.go
+++ b/srv/util_test.go
@@ -36,6 +36,7 @@ const expectedDocsOutput = `%s
 %s
 %s
 /etc/shared
+true
 `
 
 func assertMakefileOutput(t *testing.T, tmpDir, baseURL, project, owner, version string) {
@@ -162,7 +163,8 @@ docs:
 	echo "$(REPOSITORY)" >> $$OUTPUT; \
 	echo "$(REPOSITORY_OWNER)" >> $$OUTPUT; \
 	echo "$(VERSION_NAME)" >> $$OUTPUT; \
-	echo "$(SHARED_FOLDER)" >> $$OUTPUT;
+	echo "$(SHARED_FOLDER)" >> $$OUTPUT; \
+	echo "$(DOCSRV)" >> $$OUTPUT;
 `
 
 func tarGzMakefileHandler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
The motivation behind this can be seen on the example makefiles of https://github.com/src-d/ci/pull/19

Basically, it's meant for client makefiles to distinguish if they are in a DOCSRV environment or not. That way docs can also be built locally (if required dependencies are installed).