### PR TITLE
Use a GitHub token if present in tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 bin
 public
 logs
+.env

--- a/README.md
+++ b/README.md
@@ -124,3 +124,8 @@ Then mount it as a volume using `-v /path/to/mydir:/etc/docsrv` and `-v /path/to
 2. `/` without any version has the second highest predecence and acts as if it was `/latest/`.
 3. `/$VERSION/$PATH` has the lowest precedence.
 4. `/var/www/public/errors/$PATH`
+
+### Develop
+
+You may use the `dotenv.example` file as a template for a `.env` file. There
+you can uncomment and set some env variables.

--- a/docsrv/fetcher_test.go
+++ b/docsrv/fetcher_test.go
@@ -1,6 +1,7 @@
 package docsrv
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -12,8 +13,9 @@ const (
 )
 
 func TestReleases(t *testing.T) {
+	apiKey := os.Getenv("GITHUB_API_KEY")
 	require := require.New(t)
-	fetcher := newReleaseFetcher("", 1)
+	fetcher := newReleaseFetcher(apiKey, 1)
 
 	releases, err := fetcher.releases(testOwner, testProject, newVersion("v1.4.0"))
 	require.NoError(err)

--- a/dotenv.example
+++ b/dotenv.example
@@ -1,0 +1,1 @@
+#GITHUB_API_TOKEN= 


### PR DESCRIPTION
If a GitHub token is present in environment, it is used in the fetcher
tests.

Furthermore, and example dotenv file is provided if anyone wants to use
it in develop.